### PR TITLE
Clarify exported secret size for response keys

### DIFF
--- a/draft-ietf-ohai-ohttp.md
+++ b/draft-ietf-ohai-ohttp.md
@@ -721,7 +721,7 @@ Gateway Resource uses the HPKE receiver context, `rctxt`, as the HPKE context,
 In pseudocode, this procedure is as follows:
 
 ~~~
-secret = context.Export("message/bhttp response", Nk)
+secret = context.Export("message/bhttp response", max(Nn, Nk))
 response_nonce = random(max(Nn, Nk))
 salt = concat(enc, response_nonce)
 prk = Extract(salt, secret)


### PR DESCRIPTION
The text in Step 1 of section 4.4 states the secret size is `max(Nk, Nn)` but the pseudo-code below it only mentions `Nk`. The pseudo-code can be updated. In practice Nk is the same as the max. The ohttp-rs code also already has the explicit max operation.